### PR TITLE
Broadcast mempool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.vscode
 /chain/assets
 /types/pkg
+
+targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
+ "commonware-broadcast",
  "commonware-consensus",
  "commonware-cryptography",
  "commonware-deployer",
@@ -806,6 +807,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "commonware-broadcast"
+version = "0.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2845a125a1996d82604970a3d72c4fd68e314432ff33023dafbde3a0d788ca2"
+dependencies = [
+ "bytes",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-p2p",
+ "commonware-runtime",
+ "commonware-storage",
+ "commonware-utils",
+ "futures",
+ "prometheus-client",
+ "prost",
+ "prost-build",
+ "rand",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
 name = "commonware-consensus"
 version = "0.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,8 +876,6 @@ dependencies = [
 [[package]]
 name = "commonware-deployer"
 version = "0.0.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f986a14b443a53c96ad1831c9826e35dbb0aeccaad34a289fe4000d61d0a9c6"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "serde_yaml",
  "sysinfo",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,8 @@ dependencies = [
 [[package]]
 name = "commonware-deployer"
 version = "0.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f986a14b443a53c96ad1831c9826e35dbb0aeccaad34a289fe4000d61d0a9c6"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,6 @@ dependencies = [
  "serde_yaml",
  "sysinfo",
  "thiserror 2.0.12",
- "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ tracing-subscriber = "0.3.19"
 governor = "0.6.3"
 prometheus-client = "0.22.3"
 clap = "4.5.18"
-tokio = "1.43.0"
 
 [profile.bench]
 # Because we enable overflow checks in "release," we should benchmark with them.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tracing-subscriber = "0.3.19"
 governor = "0.6.3"
 prometheus-client = "0.22.3"
 clap = "4.5.18"
+tokio = "1.43.0"
 
 [profile.bench]
 # Because we enable overflow checks in "release," we should benchmark with them.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ alto-client = { version = "0.0.6", path = "client" }
 alto-types = { version = "0.0.6", path = "types" }
 commonware-consensus = { version = "0.0.43" }
 commonware-cryptography = { version = "0.0.43" }
-commonware-deployer = { version = "0.0.43" }
+# commonware-deployer = { version = "0.0.43" }
+commonware-deployer = { path = "..//cm-monorop/deployer" }
 commonware-macros = { version = "0.0.43" }
 commonware-p2p = { version = "0.0.43" }
 commonware-resolver = { version = "0.0.43" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 [workspace.dependencies]
 alto-client = { version = "0.0.6", path = "client" }
 alto-types = { version = "0.0.6", path = "types" }
+commonware-broadcast = { version = "0.0.43" }
 commonware-consensus = { version = "0.0.43" }
 commonware-cryptography = { version = "0.0.43" }
 # commonware-deployer = { version = "0.0.43" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ alto-types = { version = "0.0.6", path = "types" }
 commonware-broadcast = { version = "0.0.43" }
 commonware-consensus = { version = "0.0.43" }
 commonware-cryptography = { version = "0.0.43" }
-# commonware-deployer = { version = "0.0.43" }
-commonware-deployer = { path = "..//cm-monorop/deployer" }
+commonware-deployer = { version = "0.0.43" }
 commonware-macros = { version = "0.0.43" }
 commonware-p2p = { version = "0.0.43" }
 commonware-resolver = { version = "0.0.43" }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -32,7 +32,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 governor = { workspace = true }
 prometheus-client = { workspace = true }
-tokio = { workspace = true , features = ["time"] }
 clap = { workspace = true }
 sysinfo = "0.33.1"
 axum = "0.8.1"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/alto-chain"
 [dependencies]
 alto-types = { workspace = true }
 alto-client = { workspace = true }
+commonware-broadcast = { workspace = true }
 commonware-consensus = { workspace = true }
 commonware-cryptography = { workspace = true }
 commonware-deployer = { workspace = true }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -32,6 +32,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "json"] }
 governor = { workspace = true }
 prometheus-client = { workspace = true }
+tokio = { workspace = true , features = ["time"] }
 clap = { workspace = true }
 sysinfo = "0.33.1"
 axum = "0.8.1"

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -42,13 +42,13 @@ impl<D: Digest, P: Array> Actor<D, P> {
                     }
                 }
                 Message::Verify(_context, _payload, sender) => {
-                    // TODO: backfill inplace?
+                    debug!(digest=?_payload, "incoming verification request");
                     let Some(_) = mempool.get_batch(_payload).await else {
                         warn!(?_payload, "batch not exists");
                         let _ = sender.send(false);
                         continue;
                     };
-                    debug!("issue verfication to batch {}", _payload);
+                    debug!("issue verfication to batch={}", _payload);
                     let result = sender.send(true);
                     if result.is_err() {
                         error!("verify dropped");

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -1,10 +1,10 @@
 use super:: ingress::{Mailbox, Message};
-use commonware_broadcast::{linked::Context, Application as A, Broadcaster};
+use commonware_broadcast::Broadcaster;
 use commonware_cryptography::Digest;
 use commonware_utils::Array;
 use futures::{
-    channel::{mpsc, oneshot},
-    SinkExt, StreamExt,
+    channel::mpsc,
+    StreamExt,
 };
 use tracing::error;
 

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -1,4 +1,4 @@
-use super::{ ingress::{Mailbox, Message}, mempool::{self, Batch}};
+use super::{ ingress::{Mailbox, Message}, mempool};
 use commonware_broadcast::Broadcaster;
 use commonware_cryptography::Digest;
 use commonware_utils::Array;

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -11,7 +11,6 @@ use tracing::{error, warn, debug};
 
 pub struct Actor<D: Digest, P: Array> {
     mailbox: mpsc::Receiver<Message<D, P>>,
-    // TODO: add a mempool structure here
 }
 
 impl<D: Digest, P: Array> Actor<D, P> {

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -1,0 +1,51 @@
+use super:: ingress::{Mailbox, Message};
+use commonware_broadcast::{linked::Context, Application as A, Broadcaster};
+use commonware_cryptography::Digest;
+use commonware_utils::Array;
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt, StreamExt,
+};
+use tracing::error;
+
+
+pub struct Actor<D: Digest, P: Array> {
+    mailbox: mpsc::Receiver<Message<D, P>>,
+    // TODO: add a mempool structure here
+}
+
+impl<D: Digest, P: Array> Actor<D, P> {
+    pub fn new() -> (Self, Mailbox<D, P>) {
+        let (sender, receiver) = mpsc::channel(1024);
+        (Actor { mailbox: receiver }, Mailbox::new(sender))
+    }
+
+    pub async fn run(mut self, mut engine: impl Broadcaster<Digest = D>) {
+        while let Some(msg) = self.mailbox.next().await {
+            match msg {
+                Message::Broadcast(payload) => {
+                    let receiver = engine.broadcast(payload).await;
+                    let result = receiver.await;
+                    match result {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            error!("broadcast returned false")
+                        }
+                        Err(_) => {
+                            error!("broadcast dropped")
+                        }
+                    }
+                }
+                Message::Verify(_context, _payload, sender) => {
+                    // TODO: add handler here to process batch received
+                    let result = sender.send(true);
+                    if result.is_err() {
+                        error!("verify dropped");
+                    }
+                }
+            }
+        }
+    }
+
+    // TODO: implement handler for data received
+}

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -56,6 +56,4 @@ impl<D: Digest, P: Array> Actor<D, P> {
             }
         }
     }
-
-    // TODO: implement handler for data received
 }

--- a/chain/src/actors/mempool/actor.rs
+++ b/chain/src/actors/mempool/actor.rs
@@ -21,6 +21,7 @@ impl<D: Digest, P: Array> Actor<D, P> {
     }
 
     pub async fn run(mut self, mut engine: impl Broadcaster<Digest = D>) {
+        // it passes msgs in the mailbox of the actor to the engine mailbox
         while let Some(msg) = self.mailbox.next().await {
             match msg {
                 Message::Broadcast(payload) => {

--- a/chain/src/actors/mempool/archive.rs
+++ b/chain/src/actors/mempool/archive.rs
@@ -5,8 +5,6 @@ use commonware_utils::Array;
 use futures::lock::Mutex;
 use std::sync::Arc;
 
-const BATCH_INDEX: u64 = 0;
-
 /// Archive wrapper that handles all locking.
 #[derive(Clone)]
 pub struct Wrapped<T, K, B, R>
@@ -43,23 +41,22 @@ where
     }
 
     /// Inserts a value into the archive with the given index and key.
-    pub async fn put(&self, key: K, data: Bytes) -> Result<(), archive::Error> {
+    pub async fn put(&self, index: u64, key: K, data: Bytes) -> Result<(), archive::Error> {
         let mut archive = self.inner.lock().await;
-        archive.put(BATCH_INDEX, key, data).await?;
+        archive.put(index, key, data).await?;
         Ok(())
     }
 
-    // TODO: revisit: do we need to prune as a DA?
-    // /// Prunes entries from the archive up to the specified minimum index.
-    // pub async fn prune(&self, min_index: u64) -> Result<(), archive::Error> {
-    //     let mut archive = self.inner.lock().await;
-    //     archive.prune(min_index).await?;
-    //     Ok(())
-    // }
+    /// Prunes entries from the archive up to the specified minimum index.
+    pub async fn prune(&self, min_index: u64) -> Result<(), archive::Error> {
+        let mut archive = self.inner.lock().await;
+        archive.prune(min_index).await?;
+        Ok(())
+    }
 
-    // /// Retrieves the next gap in the archive.
-    // pub async fn next_gap(&self, start: u64) -> (Option<u64>, Option<u64>) {
-    //     let archive = self.inner.lock().await;
-    //     archive.next_gap(start)
-    // }
+    /// Retrieves the next gap in the archive.
+    pub async fn next_gap(&self, start: u64) -> (Option<u64>, Option<u64>) {
+        let archive = self.inner.lock().await;
+        archive.next_gap(start)
+    }
 }

--- a/chain/src/actors/mempool/archive.rs
+++ b/chain/src/actors/mempool/archive.rs
@@ -1,0 +1,65 @@
+use bytes::Bytes;
+use commonware_runtime::{Blob, Metrics, Storage};
+use commonware_storage::archive::{self, Archive, Identifier, Translator};
+use commonware_utils::Array;
+use futures::lock::Mutex;
+use std::sync::Arc;
+
+const BATCH_INDEX: u64 = 0;
+
+/// Archive wrapper that handles all locking.
+#[derive(Clone)]
+pub struct Wrapped<T, K, B, R>
+where
+    T: Translator,
+    K: Array,
+    B: Blob,
+    R: Storage<B> + Metrics,
+{
+    inner: Arc<Mutex<Archive<T, K, B, R>>>,
+}
+
+impl<T, K, B, R> Wrapped<T, K, B, R>
+where
+    T: Translator,
+    K: Array,
+    B: Blob,
+    R: Storage<B> + Metrics,
+{
+    /// Creates a new `Wrapped` from an existing `Archive`.
+    pub fn new(archive: Archive<T, K, B, R>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(archive)),
+        }
+    }
+
+    /// Retrieves a value from the archive by identifier.
+    pub async fn get(
+        &self,
+        identifier: Identifier<'_, K>,
+    ) -> Result<Option<Bytes>, archive::Error> {
+        let archive = self.inner.lock().await;
+        archive.get(identifier).await
+    }
+
+    /// Inserts a value into the archive with the given index and key.
+    pub async fn put(&self, key: K, data: Bytes) -> Result<(), archive::Error> {
+        let mut archive = self.inner.lock().await;
+        archive.put(BATCH_INDEX, key, data).await?;
+        Ok(())
+    }
+
+    // TODO: revisit: do we need to prune as a DA?
+    // /// Prunes entries from the archive up to the specified minimum index.
+    // pub async fn prune(&self, min_index: u64) -> Result<(), archive::Error> {
+    //     let mut archive = self.inner.lock().await;
+    //     archive.prune(min_index).await?;
+    //     Ok(())
+    // }
+
+    // /// Retrieves the next gap in the archive.
+    // pub async fn next_gap(&self, start: u64) -> (Option<u64>, Option<u64>) {
+    //     let archive = self.inner.lock().await;
+    //     archive.next_gap(start)
+    // }
+}

--- a/chain/src/actors/mempool/collector.rs
+++ b/chain/src/actors/mempool/collector.rs
@@ -14,9 +14,7 @@ use super::mempool;
 
 enum Message<C: Scheme, D: Digest> {
     Acknowledged(Proof, D),
-    GetTip(C::PublicKey, oneshot::Sender<Option<u64>>),
-    GetContiguousTip(C::PublicKey, oneshot::Sender<Option<u64>>),
-    Get(C::PublicKey, u64, oneshot::Sender<Option<D>>),
+    _Phantom(C::PublicKey),    
 }
 
 pub struct Collector<C: Scheme, D: Digest> {
@@ -27,15 +25,6 @@ pub struct Collector<C: Scheme, D: Digest> {
 
     // Public key of the group
     public: group::Public,
-
-    // All known digests
-    digests: HashMap<C::PublicKey, BTreeMap<u64, D>>,
-
-    // Highest contiguous known height for each sequencer
-    contiguous: HashMap<C::PublicKey, u64>,
-
-    // Highest known height for each sequencer
-    highest: HashMap<C::PublicKey, u64>,
 }
 
 impl<C: Scheme, D: Digest> Collector<C, D> {
@@ -46,9 +35,6 @@ impl<C: Scheme, D: Digest> Collector<C, D> {
                 mailbox: receiver,
                 namespace: namespace.to_vec(),
                 public,
-                digests: HashMap::new(),
-                contiguous: HashMap::new(),
-                highest: HashMap::new(),
             },
             Mailbox { sender },
         )
@@ -61,7 +47,7 @@ impl<C: Scheme, D: Digest> Collector<C, D> {
                     // Check proof.
                     // The prover checks the validity of the threshold signature when deserializing
                     let prover = Prover::<C, D>::new(&self.namespace, self.public);
-                    let context = match prover.deserialize_threshold(proof) {
+                    let _ = match prover.deserialize_threshold(proof) {
                         Some((context, _payload, _epoch, _threshold)) => context,
                         None => {
                             error!("invalid proof");
@@ -74,44 +60,8 @@ impl<C: Scheme, D: Digest> Collector<C, D> {
                     if !acknowledge {
                         error!("unable to acknowledge batch {}", payload)
                     }
-
-                    // Update the collector
-                    let digests = self.digests.entry(context.sequencer.clone()).or_default();
-                    digests.insert(context.height, payload);
-
-                    // Update the highest height
-                    let highest = self.highest.get(&context.sequencer).copied().unwrap_or(0);
-                    self.highest
-                        .insert(context.sequencer.clone(), max(highest, context.height));
-
-                    // Update the highest contiguous height
-                    let highest = self.contiguous.get(&context.sequencer);
-                    if (highest.is_none() && context.height == 0)
-                        || (highest.is_some() && context.height == highest.unwrap() + 1)
-                    {
-                        let mut contiguous = context.height;
-                        while digests.contains_key(&(contiguous + 1)) {
-                            contiguous += 1;
-                        }
-                        self.contiguous.insert(context.sequencer, contiguous);
-                    }
                 }
-                Message::GetTip(sequencer, sender) => {
-                    let hi = self.highest.get(&sequencer).copied();
-                    sender.send(hi).unwrap();
-                }
-                Message::GetContiguousTip(sequencer, sender) => {
-                    let contiguous = self.contiguous.get(&sequencer).copied();
-                    sender.send(contiguous).unwrap();
-                }
-                Message::Get(sequencer, height, sender) => {
-                    let digest = self
-                        .digests
-                        .get(&sequencer)
-                        .and_then(|map| map.get(&height))
-                        .cloned();
-                    sender.send(digest).unwrap();
-                }
+                _ => unreachable!()
             }
         }
     }
@@ -129,34 +79,5 @@ impl<C: Scheme, D: Digest> Z for Mailbox<C, D> {
             .send(Message::Acknowledged(proof, payload))
             .await
             .expect("Failed to send acknowledged");
-    }
-}
-
-impl<C: Scheme, D: Digest> Mailbox<C, D> {
-    pub async fn get_tip(&mut self, sequencer: C::PublicKey) -> Option<u64> {
-        let (sender, receiver) = oneshot::channel();
-        self.sender
-            .send(Message::GetTip(sequencer, sender))
-            .await
-            .unwrap();
-        receiver.await.unwrap()
-    }
-
-    pub async fn get_contiguous_tip(&mut self, sequencer: C::PublicKey) -> Option<u64> {
-        let (sender, receiver) = oneshot::channel();
-        self.sender
-            .send(Message::GetContiguousTip(sequencer, sender))
-            .await
-            .unwrap();
-        receiver.await.unwrap()
-    }
-
-    pub async fn get(&mut self, sequencer: C::PublicKey, height: u64) -> Option<D> {
-        let (sender, receiver) = oneshot::channel();
-        self.sender
-            .send(Message::Get(sequencer, height, sender))
-            .await
-            .unwrap();
-        receiver.await.unwrap()
     }
 }

--- a/chain/src/actors/mempool/collector.rs
+++ b/chain/src/actors/mempool/collector.rs
@@ -1,0 +1,154 @@
+use commonware_broadcast::{linked::Prover, Collector as Z, Proof, };
+use commonware_cryptography::{bls12381::primitives::group, Digest, Scheme};
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt, StreamExt,
+};
+use std::{
+    cmp::max,
+    collections::{BTreeMap, HashMap},
+};
+use tracing::error;
+
+enum Message<C: Scheme, D: Digest> {
+    Acknowledged(Proof, D),
+    GetTip(C::PublicKey, oneshot::Sender<Option<u64>>),
+    GetContiguousTip(C::PublicKey, oneshot::Sender<Option<u64>>),
+    Get(C::PublicKey, u64, oneshot::Sender<Option<D>>),
+}
+
+pub struct Collector<C: Scheme, D: Digest> {
+    mailbox: mpsc::Receiver<Message<C, D>>,
+
+    // Application namespace
+    namespace: Vec<u8>,
+
+    // Public key of the group
+    public: group::Public,
+
+    // All known digests
+    digests: HashMap<C::PublicKey, BTreeMap<u64, D>>,
+
+    // Highest contiguous known height for each sequencer
+    contiguous: HashMap<C::PublicKey, u64>,
+
+    // Highest known height for each sequencer
+    highest: HashMap<C::PublicKey, u64>,
+}
+
+impl<C: Scheme, D: Digest> Collector<C, D> {
+    pub fn new(namespace: &[u8], public: group::Public) -> (Self, Mailbox<C, D>) {
+        let (sender, receiver) = mpsc::channel(1024);
+        (
+            Collector {
+                mailbox: receiver,
+                namespace: namespace.to_vec(),
+                public,
+                digests: HashMap::new(),
+                contiguous: HashMap::new(),
+                highest: HashMap::new(),
+            },
+            Mailbox { sender },
+        )
+    }
+
+    pub async fn run(mut self) {
+        while let Some(msg) = self.mailbox.next().await {
+            match msg {
+                Message::Acknowledged(proof, payload) => {
+                    // Check proof.
+                    // The prover checks the validity of the threshold signature when deserializing
+                    let prover = Prover::<C, D>::new(&self.namespace, self.public);
+                    let context = match prover.deserialize_threshold(proof) {
+                        Some((context, _payload, _epoch, _threshold)) => context,
+                        None => {
+                            error!("invalid proof");
+                            continue;
+                        }
+                    };
+
+                    // Update the collector
+                    let digests = self.digests.entry(context.sequencer.clone()).or_default();
+                    digests.insert(context.height, payload);
+
+                    // Update the highest height
+                    let highest = self.highest.get(&context.sequencer).copied().unwrap_or(0);
+                    self.highest
+                        .insert(context.sequencer.clone(), max(highest, context.height));
+
+                    // Update the highest contiguous height
+                    let highest = self.contiguous.get(&context.sequencer);
+                    if (highest.is_none() && context.height == 0)
+                        || (highest.is_some() && context.height == highest.unwrap() + 1)
+                    {
+                        let mut contiguous = context.height;
+                        while digests.contains_key(&(contiguous + 1)) {
+                            contiguous += 1;
+                        }
+                        self.contiguous.insert(context.sequencer, contiguous);
+                    }
+                }
+                Message::GetTip(sequencer, sender) => {
+                    let hi = self.highest.get(&sequencer).copied();
+                    sender.send(hi).unwrap();
+                }
+                Message::GetContiguousTip(sequencer, sender) => {
+                    let contiguous = self.contiguous.get(&sequencer).copied();
+                    sender.send(contiguous).unwrap();
+                }
+                Message::Get(sequencer, height, sender) => {
+                    let digest = self
+                        .digests
+                        .get(&sequencer)
+                        .and_then(|map| map.get(&height))
+                        .cloned();
+                    sender.send(digest).unwrap();
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Mailbox<C: Scheme, D: Digest> {
+    sender: mpsc::Sender<Message<C, D>>,
+}
+
+impl<C: Scheme, D: Digest> Z for Mailbox<C, D> {
+    type Digest = D;
+    async fn acknowledged(&mut self, proof: Proof, payload: Self::Digest) {
+        self.sender
+            .send(Message::Acknowledged(proof, payload))
+            .await
+            .expect("Failed to send acknowledged");
+    }
+}
+
+impl<C: Scheme, D: Digest> Mailbox<C, D> {
+    pub async fn get_tip(&mut self, sequencer: C::PublicKey) -> Option<u64> {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::GetTip(sequencer, sender))
+            .await
+            .unwrap();
+        receiver.await.unwrap()
+    }
+
+    pub async fn get_contiguous_tip(&mut self, sequencer: C::PublicKey) -> Option<u64> {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::GetContiguousTip(sequencer, sender))
+            .await
+            .unwrap();
+        receiver.await.unwrap()
+    }
+
+    pub async fn get(&mut self, sequencer: C::PublicKey, height: u64) -> Option<D> {
+        let (sender, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::Get(sequencer, height, sender))
+            .await
+            .unwrap();
+        receiver.await.unwrap()
+    }
+}

--- a/chain/src/actors/mempool/collector.rs
+++ b/chain/src/actors/mempool/collector.rs
@@ -1,12 +1,8 @@
 use commonware_broadcast::{linked::Prover, Collector as Z, Proof, };
 use commonware_cryptography::{bls12381::primitives::group, Digest, Scheme};
 use futures::{
-    channel::{mpsc, oneshot},
+    channel::mpsc,
     SinkExt, StreamExt,
-};
-use std::{
-    cmp::max,
-    collections::{BTreeMap, HashMap},
 };
 use tracing::error;
 

--- a/chain/src/actors/mempool/coordinator.rs
+++ b/chain/src/actors/mempool/coordinator.rs
@@ -1,0 +1,80 @@
+use commonware_broadcast::{linked::Epoch, Coordinator as S, ThresholdCoordinator as T};
+use commonware_cryptography::bls12381::primitives::{
+    group::{Public, Share},
+    poly::Poly,
+};
+use commonware_utils::Array;
+use std::collections::HashMap;
+
+// TODO: The implementation is copied from commonware-broadcast::linked::mocks, should be updated to track the 
+/// Implementation of `commonware-consensus::Coordinator`. 
+#[derive(Clone)]
+pub struct Coordinator<P: Array> {
+    view: u64,
+    identity: Poly<Public>,
+    signers: Vec<P>,
+    signers_map: HashMap<P, u32>,
+    share: Share,
+}
+
+impl<P: Array> Coordinator<P> {
+    pub fn new(identity: Poly<Public>, mut signers: Vec<P>, share: Share) -> Self {
+        // Setup signers
+        signers.sort();
+        let mut signers_map = HashMap::new();
+        for (index, validator) in signers.iter().enumerate() {
+            signers_map.insert(validator.clone(), index as u32);
+        }
+
+        // Return coordinator
+        Self {
+            view: 0,
+            identity,
+            signers,
+            signers_map,
+            share,
+        }
+    }
+
+    pub fn set_view(&mut self, view: u64) {
+        self.view = view;
+    }
+}
+
+impl<P: Array> S for Coordinator<P> {
+    type Index = Epoch;
+    type PublicKey = P;
+
+    fn index(&self) -> Self::Index {
+        self.view
+    }
+
+    fn signers(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+        Some(&self.signers)
+    }
+
+    fn is_signer(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
+        self.signers_map.get(candidate).cloned()
+    }
+
+    fn sequencers(&self, _: Self::Index) -> Option<&Vec<Self::PublicKey>> {
+        Some(&self.signers)
+    }
+
+    fn is_sequencer(&self, _: Self::Index, candidate: &Self::PublicKey) -> Option<u32> {
+        self.signers_map.get(candidate).cloned()
+    }
+}
+
+impl<P: Array> T for Coordinator<P> {
+    type Identity = Poly<Public>;
+    type Share = Share;
+
+    fn identity(&self, _: Self::Index) -> Option<&Self::Identity> {
+        Some(&self.identity)
+    }
+
+    fn share(&self, _: Self::Index) -> Option<&Self::Share> {
+        Some(&self.share)
+    }
+}

--- a/chain/src/actors/mempool/coordinator.rs
+++ b/chain/src/actors/mempool/coordinator.rs
@@ -3,7 +3,7 @@ use commonware_cryptography::bls12381::primitives::{
     group::{Public, Share},
     poly::Poly,
 };
-use commonware_resolver::{p2p};
+use commonware_resolver::p2p;
 use commonware_utils::Array;
 use std::collections::HashMap;
 

--- a/chain/src/actors/mempool/coordinator.rs
+++ b/chain/src/actors/mempool/coordinator.rs
@@ -3,6 +3,7 @@ use commonware_cryptography::bls12381::primitives::{
     group::{Public, Share},
     poly::Poly,
 };
+use commonware_resolver::{p2p};
 use commonware_utils::Array;
 use std::collections::HashMap;
 
@@ -76,5 +77,17 @@ impl<P: Array> T for Coordinator<P> {
 
     fn share(&self, _: Self::Index) -> Option<&Self::Share> {
         Some(&self.share)
+    }
+}
+
+impl <P: Array> p2p::Coordinator for Coordinator<P>  {
+    type PublicKey = P; 
+
+    fn peers(&self) -> &Vec<Self::PublicKey> {
+        &self.signers        
+    }
+
+    fn peer_set_id(&self) -> u64 {
+        0    
     }
 }

--- a/chain/src/actors/mempool/handler.rs
+++ b/chain/src/actors/mempool/handler.rs
@@ -5,6 +5,7 @@ use futures::{
     channel::{mpsc, oneshot},
     SinkExt,
 };
+use tracing::warn;
 
 pub enum Message {
     Deliver {
@@ -48,8 +49,8 @@ impl Consumer for Handler {
         receiver.await.expect("Failed to receive deliver")
     }
 
-    async fn failed(&mut self, _: Self::Key, _: Self::Failure) {
-        // Ignore any failure
+    async fn failed(&mut self, key: Self::Key, failture: Self::Failure) {
+        warn!(?key, ?failture, "failed at consumer");
     }
 }
 

--- a/chain/src/actors/mempool/handler.rs
+++ b/chain/src/actors/mempool/handler.rs
@@ -1,0 +1,67 @@
+use super::key::MultiIndex;
+use bytes::Bytes;
+use commonware_resolver::{p2p::Producer, Consumer};
+use futures::{
+    channel::{mpsc, oneshot},
+    SinkExt,
+};
+
+pub enum Message {
+    Deliver {
+        key: MultiIndex,
+        value: Bytes,
+        response: oneshot::Sender<bool>,
+    },
+    Produce {
+        key: MultiIndex,
+        response: oneshot::Sender<Bytes>,
+    },
+}
+
+/// Mailbox for resolver
+#[derive(Clone)]
+pub struct Handler {
+    sender: mpsc::Sender<Message>,
+}
+
+impl Handler {
+    pub(super) fn new(sender: mpsc::Sender<Message>) -> Self {
+        Self { sender }
+    }
+}
+
+impl Consumer for Handler {
+    type Key = MultiIndex;
+    type Value = Bytes;
+    type Failure = ();
+
+    async fn deliver(&mut self, key: Self::Key, value: Self::Value) -> bool {
+        let (response, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::Deliver {
+                key,
+                value,
+                response,
+            })
+            .await
+            .expect("Failed to send deliver");
+        receiver.await.expect("Failed to receive deliver")
+    }
+
+    async fn failed(&mut self, _: Self::Key, _: Self::Failure) {
+        // Ignore any failure
+    }
+}
+
+impl Producer for Handler {
+    type Key = MultiIndex;
+
+    async fn produce(&mut self, key: Self::Key) -> oneshot::Receiver<Bytes> {
+        let (response, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::Produce { key, response })
+            .await
+            .expect("Failed to send produce");
+        receiver
+    }
+}

--- a/chain/src/actors/mempool/ingress.rs
+++ b/chain/src/actors/mempool/ingress.rs
@@ -1,7 +1,11 @@
-use commonware_utils::Array;
+use commonware_utils::{Array, SizedSerialize};
 use commonware_cryptography::Digest;
 use commonware_broadcast::{linked::Context, Application as A, Broadcaster};
 use futures::{ channel::{mpsc, oneshot}, SinkExt};
+
+pub struct Payload {
+    data: Vec<u8>
+}
 
 pub enum Message<D: Digest, P: Array> {
     Broadcast(D),

--- a/chain/src/actors/mempool/ingress.rs
+++ b/chain/src/actors/mempool/ingress.rs
@@ -1,6 +1,6 @@
-use commonware_utils::{Array, SizedSerialize};
+use commonware_utils::Array;
 use commonware_cryptography::Digest;
-use commonware_broadcast::{linked::Context, Application as A, Broadcaster};
+use commonware_broadcast::{linked::Context, Application as A};
 use futures::{ channel::{mpsc, oneshot}, SinkExt};
 
 pub struct Payload {

--- a/chain/src/actors/mempool/ingress.rs
+++ b/chain/src/actors/mempool/ingress.rs
@@ -4,6 +4,7 @@ use commonware_broadcast::{linked::Context, Application as A};
 use futures::{ channel::{mpsc, oneshot}, SinkExt};
 
 pub struct Payload {
+    #[allow(dead_code)]
     data: Vec<u8>
 }
 

--- a/chain/src/actors/mempool/ingress.rs
+++ b/chain/src/actors/mempool/ingress.rs
@@ -1,0 +1,44 @@
+use commonware_utils::Array;
+use commonware_cryptography::Digest;
+use commonware_broadcast::{linked::Context, Application as A, Broadcaster};
+use futures::{ channel::{mpsc, oneshot}, SinkExt};
+
+pub enum Message<D: Digest, P: Array> {
+    Broadcast(D),
+    Verify(Context<P>, D, oneshot::Sender<bool>),
+}
+
+#[derive(Clone)]
+pub struct Mailbox<D: Digest, P: Array> {
+    sender: mpsc::Sender<Message<D, P>>,
+}
+
+impl<D: Digest, P: Array> Mailbox<D, P> {
+    pub(super) fn new(sender: mpsc::Sender<Message<D, P>>) -> Self {
+        Self {
+            sender
+        }
+    }
+
+    pub async fn broadcast(&mut self, payload: D) {
+        let _ = self.sender.send(Message::Broadcast(payload)).await;
+    }
+}
+
+impl<D: Digest, P: Array> A for Mailbox<D, P> {
+    type Context = Context<P>;
+    type Digest = D;
+
+    async fn verify(
+        &mut self,
+        context: Self::Context,
+        payload: Self::Digest,
+    ) -> oneshot::Receiver<bool> {
+        let (sender, receiver) = oneshot::channel();
+        let _ = self
+            .sender
+            .send(Message::Verify(context, payload, sender))
+            .await;
+        receiver
+    }
+}

--- a/chain/src/actors/mempool/key.rs
+++ b/chain/src/actors/mempool/key.rs
@@ -1,0 +1,132 @@
+use commonware_cryptography::sha256::Digest;
+use commonware_utils::{Array, SizedSerialize};
+use std::{
+    cmp::{Ord, PartialOrd},
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::Deref,
+};
+use thiserror::Error;
+
+const SERIALIZED_LEN: usize = 1 + Digest::SERIALIZED_LEN;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum Error {
+    #[error("invalid length")]
+    InvalidLength,
+}
+
+pub enum Value {
+    Digest(Digest),
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct MultiIndex([u8; SERIALIZED_LEN]);
+
+impl MultiIndex {
+    pub fn new(value: Value) -> Self {
+        let mut bytes = [0; SERIALIZED_LEN];
+        match value {
+            Value::Digest(digest) => {
+                bytes[0] = 0;
+                bytes[1..].copy_from_slice(&digest);
+            }
+        }
+        Self(bytes)
+    }
+
+    pub fn to_value(&self) -> Value {
+        match self.0[0] {
+            0 => {
+                let bytes: [u8; Digest::SERIALIZED_LEN] = self.0[1..].try_into().unwrap();
+                let digest = Digest::from(bytes);
+                Value::Digest(digest)
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Array for MultiIndex {
+    type Error = Error;
+}
+
+impl SizedSerialize for MultiIndex {
+    const SERIALIZED_LEN: usize = SERIALIZED_LEN;
+}
+
+impl From<[u8; MultiIndex::SERIALIZED_LEN]> for MultiIndex {
+    fn from(value: [u8; MultiIndex::SERIALIZED_LEN]) -> Self {
+        Self(value)
+    }
+}
+
+impl TryFrom<&[u8]> for MultiIndex {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != MultiIndex::SERIALIZED_LEN {
+            return Err(Error::InvalidLength);
+        }
+        let array: [u8; MultiIndex::SERIALIZED_LEN] =
+            value.try_into().map_err(|_| Error::InvalidLength)?;
+        Ok(Self(array))
+    }
+}
+
+impl TryFrom<&Vec<u8>> for MultiIndex {
+    type Error = Error;
+
+    fn try_from(value: &Vec<u8>) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_slice())
+    }
+}
+
+impl TryFrom<Vec<u8>> for MultiIndex {
+    type Error = Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        if value.len() != MultiIndex::SERIALIZED_LEN {
+            return Err(Error::InvalidLength);
+        }
+
+        // If the length is correct, we can safely convert the vector into a boxed slice without any
+        // copies.
+        let boxed_slice = value.into_boxed_slice();
+        let boxed_array: Box<[u8; MultiIndex::SERIALIZED_LEN]> =
+            boxed_slice.try_into().map_err(|_| Error::InvalidLength)?;
+        Ok(Self(*boxed_array))
+    }
+}
+
+impl AsRef<[u8]> for MultiIndex {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Deref for MultiIndex {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Debug for MultiIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0[0] {
+            0 => {
+                let bytes: [u8; Digest::SERIALIZED_LEN] = self.0[1..].try_into().unwrap();
+                write!(f, "digest({})", Digest::from(bytes))
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Display for MultiIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
+    }
+}

--- a/chain/src/actors/mempool/mempool.rs
+++ b/chain/src/actors/mempool/mempool.rs
@@ -1,13 +1,12 @@
-use core::num;
 use std::{collections::HashMap, time::{Duration, SystemTime}};
 
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{BufMut, Bytes};
 use commonware_cryptography::{ed25519::PublicKey, sha256::Digest, Hasher, Sha256};
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, Handle, Spawner};
 use futures::{channel::{mpsc, oneshot}, SinkExt, StreamExt};
 use commonware_macros::select;
-use tokio::{io::AsyncReadExt, time};
+use tokio::time;
 use tracing::{debug, warn};
 
 #[derive(Clone)]
@@ -157,7 +156,7 @@ impl Mailbox {
     pub async fn issue_tx(&mut self, tx: RawTransaction) -> bool {
         let (response, receiver) = oneshot::channel();
         self.sender
-            .send(Message::SubmitTx { payload: tx, response: response })
+            .send(Message::SubmitTx { payload: tx, response })
             .await
             .expect("failed to issue tx");
 
@@ -167,7 +166,7 @@ impl Mailbox {
     pub async fn get_tx(&mut self, digest: Digest) -> Option<RawTransaction> {
         let (response, receiver) = oneshot::channel();
         self.sender
-            .send(Message::GetTx { digest: digest, response: response })
+            .send(Message::GetTx { digest, response })
             .await
             .expect("failed to get tx");
 

--- a/chain/src/actors/mempool/mempool.rs
+++ b/chain/src/actors/mempool/mempool.rs
@@ -279,6 +279,8 @@ pub struct Mempool<
     batches: HashMap<D, Batch<D>>,
     
     acknowledged: Vec<D>,
+
+    //TODO: replace the following two
     accepted: Archive<TwoCap, D, B, R>,
     consumed: Archive<TwoCap, D, B, R>,
 

--- a/chain/src/actors/mempool/mempool.rs
+++ b/chain/src/actors/mempool/mempool.rs
@@ -1,7 +1,7 @@
-use std::{alloc::System, collections::HashMap, time::{Duration, SystemTime}};
+use std::{collections::HashMap, time::{Duration, SystemTime}};
 
 use bytes::{BufMut, Bytes};
-use commonware_cryptography::{bls12381::primitives::group::Public, ed25519::PublicKey, sha256, Digest, Hasher, Sha256};
+use commonware_cryptography::{ed25519::PublicKey, sha256, Digest, Hasher, Sha256};
 use commonware_p2p::{utils::requester, Receiver, Recipients, Sender};
 use commonware_runtime::{Blob, Clock, Handle, Metrics, Spawner, Storage};
 use commonware_resolver::{p2p, Resolver};
@@ -9,14 +9,14 @@ use commonware_storage::{
     archive::{self, translator::TwoCap, Archive, Identifier}, 
     journal::{self, variable::Journal},
 };
-use commonware_utils::{Array, SystemTimeExt};
+use commonware_utils::SystemTimeExt;
 use futures::{channel::{mpsc, oneshot}, SinkExt, StreamExt};
 use commonware_macros::select;
 use governor::Quota;
 use rand::Rng;
-use tracing::{debug, warn, info};
+use tracing::{debug, warn};
 use governor::clock::Clock as GClock;
-use super::{actor, handler::{Handler, self}, key::{self, MultiIndex, Value}, ingress, coordinator::Coordinator, archive::Wrapped};
+use super::{handler::{Handler, self}, key::{self, MultiIndex, Value}, ingress, coordinator::Coordinator, archive::Wrapped};
 use crate::maybe_delay_between;
 
 #[derive(Clone, Debug)]

--- a/chain/src/actors/mempool/mempool.rs
+++ b/chain/src/actors/mempool/mempool.rs
@@ -382,7 +382,7 @@ impl<
         self.context.spawn_ref()(self.run(batch_network, backfill_network, coordinator, app_mailbox))
     }
 
-    async fn run(
+    pub async fn run(
         mut self,
         mut batch_network: (
             impl Sender<PublicKey = PublicKey>,

--- a/chain/src/actors/mempool/mempool.rs
+++ b/chain/src/actors/mempool/mempool.rs
@@ -1,0 +1,283 @@
+use core::num;
+use std::{collections::HashMap, time::{Duration, SystemTime}};
+
+use bytes::{Buf, BufMut, Bytes};
+use commonware_cryptography::{ed25519::PublicKey, sha256::Digest, Hasher, Sha256};
+use commonware_p2p::{Receiver, Recipients, Sender};
+use commonware_runtime::{Clock, Handle, Spawner};
+use futures::{channel::{mpsc, oneshot}, SinkExt, StreamExt};
+use commonware_macros::select;
+use tokio::{io::AsyncReadExt, time};
+use tracing::{debug, warn};
+
+#[derive(Clone)]
+pub struct Batch  {
+    pub txs: Vec<RawTransaction>,
+
+    pub digest: Digest,
+    // mark if the batch is accepted by the network, i.e. the network has received & verified the batch 
+    pub accepted: bool, 
+    pub timestamp: SystemTime,
+}
+
+impl Batch {
+    fn compute_digest(txs: &Vec<RawTransaction>) -> Digest {
+        let mut hasher = Sha256::new();
+        for tx in txs.into_iter() {
+            hasher.update(tx.raw.as_ref());
+        }
+
+        hasher.finalize()
+    }
+
+    pub fn new(txs: Vec<RawTransaction>, timestamp: SystemTime) -> Self {
+        let digest = Self::compute_digest(&txs);
+
+        Self {
+            txs,
+            digest,
+            accepted: false,
+            timestamp 
+        }
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.put_u64(self.txs.len() as u64);
+        for tx in self.txs.iter() {
+            bytes.put_u64(tx.size());
+            bytes.extend_from_slice(&tx.raw);
+        }
+        bytes
+    }
+
+    pub fn deserialize(mut bytes: &[u8]) -> Option<Self> {
+        use bytes::Buf;
+        // We expect at least 8 bytes for the number of transactions.
+        if bytes.remaining() < 8 {
+            return None;
+        }
+        let tx_count = bytes.get_u64();
+        let mut txs = Vec::with_capacity(tx_count as usize);
+        for _ in 0..tx_count {
+            // For each transaction, first read the size (u64).
+            if bytes.remaining() < 8 {
+                return None;
+            }
+            let tx_size = bytes.get_u64() as usize;
+            // Ensure there are enough bytes left.
+            if bytes.remaining() < tx_size {
+                return None;
+            }
+            // Extract tx_size bytes.
+            let tx_bytes = bytes.copy_to_bytes(tx_size);
+            txs.push(RawTransaction::new(tx_bytes));
+        }
+        // Compute the digest from the transactions.
+        let digest = Self::compute_digest(&txs);
+        // Since serialize did not include accepted and timestamp, we set accepted to false
+        // and set timestamp to the current time.
+        Some(Self {
+            txs,
+            digest,
+            accepted: false,
+            timestamp: SystemTime::now(),
+        })
+    }
+
+    pub fn contain_tx(&self, digest: &Digest) -> bool {
+        self.txs.iter().any(|tx| &tx.digest == digest) 
+    }
+
+    pub fn tx(&self, digest: &Digest) -> Option<RawTransaction> {
+        self.txs.iter().find(|tx| &tx.digest == digest).cloned()
+    }
+}
+
+#[derive(Clone)]
+pub struct RawTransaction {
+    pub raw: Bytes,
+
+    pub digest: Digest
+}
+
+impl RawTransaction {
+    fn compute_digest(raw: &Bytes) -> Digest {
+        let mut hasher = Sha256::new();
+        hasher.update(&raw);
+        hasher.finalize()
+    }
+
+    pub fn new(raw: Bytes) -> Self {
+        let digest = Self::compute_digest(&raw);
+        Self {
+            raw,
+            digest
+        }
+    }
+
+    pub fn validate(&self) -> bool {
+        // TODO: implement validate here
+        true
+    }
+
+    pub fn size(&self) -> u64 {
+        self.raw.len() as u64
+    }
+}
+
+pub enum Message {
+    // mark batch as accepted by the netowrk through the broadcast protocol
+    BatchAccepted {
+        digest: Digest,
+    },
+    // from rpc or websocket
+    SubmitTx {
+        payload: RawTransaction,
+        response: oneshot::Sender<bool>
+    },
+    GetTx {
+        digest: Digest,
+        response: oneshot::Sender<Option<RawTransaction>>
+    },
+}
+
+#[derive(Clone)]
+pub struct Mailbox {
+    sender: mpsc::Sender<Message>
+}
+
+impl Mailbox {
+    pub fn new(sender: mpsc::Sender<Message>) -> Self {
+        Self {
+            sender
+        }
+    }
+
+    pub async fn issue_tx(&mut self, tx: RawTransaction) -> bool {
+        let (response, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::SubmitTx { payload: tx, response: response })
+            .await
+            .expect("failed to issue tx");
+
+        receiver.await.expect("failed to receive tx issue status")
+    }
+
+    pub async fn get_tx(&mut self, digest: Digest) -> Option<RawTransaction> {
+        let (response, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::GetTx { digest: digest, response: response })
+            .await
+            .expect("failed to get tx");
+
+        receiver.await.expect("failed to receive tx")
+    }
+}
+
+pub struct Config {
+    pub batch_propose_interval: Duration,
+    pub batch_size_limit: u64,
+}
+
+pub struct Mempool<R: Clock + Spawner> {
+    cfg: Config,
+    context: R,
+
+    batches: HashMap<Digest, Batch>,
+    txs: Vec<RawTransaction>,
+
+    mailbox: mpsc::Receiver<Message>
+}
+
+impl<R: Clock + Spawner> Mempool<R> {
+    pub fn new(context: R, cfg: Config) -> (Self, Mailbox) {
+        let (sender, receiver) = mpsc::channel(1024);
+        (Self {
+            cfg, 
+            context,
+            mailbox: receiver,
+            txs: vec![],
+            batches: HashMap::new(),
+        }, Mailbox::new(sender))
+    }
+
+    pub fn start(
+        mut self,
+        batch_network: (
+            impl Sender<PublicKey = PublicKey>,
+            impl Receiver<PublicKey = PublicKey>,
+        )
+    ) -> Handle<()> {
+        self.context.spawn_ref()(self.run(batch_network))
+    }
+
+    async fn run(
+        mut self,
+        mut batch_network: (
+            impl Sender<PublicKey = PublicKey>,
+            impl Receiver<PublicKey = PublicKey>,
+        ), 
+    ) {
+
+        let mut batch_propose_interval = time::interval(self.cfg.batch_propose_interval);
+        loop {
+            select! {
+                mailbox_message = self.mailbox.next() => {
+                    let message = mailbox_message.expect("Mailbox closed");
+                    match message {
+                        Message::SubmitTx { payload, response } => {
+                            if !payload.validate() {
+                                let _ = response.send(false);
+                                return;    
+                            }
+
+                            self.txs.push(payload);
+                            let _ = response.send(true);
+                        },
+                        Message::BatchAccepted { digest } => {
+                            if let Some(batch) = self.batches.get_mut(&digest) {
+                                batch.accepted = true;
+                            }
+                        },
+                        Message::GetTx { digest, response } => {
+                            // TODO: optimize this naive way of seaching
+                            let pair = self.batches.iter().find(|(_, batch)| batch.contain_tx(&digest));
+                            if let Some((_, batch)) = pair {
+                                let _ = response.send(batch.tx(&digest));
+                            } else {
+                                let _ = response.send(None);
+                            }
+                        },
+                    }
+                },
+                _ = batch_propose_interval.tick() => {
+                    let mut size = 0;
+                    let mut txs_cnt = 0;
+                    for tx in self.txs.iter() {
+                        size += tx.size();
+                        txs_cnt += 1;
+
+                        if size > self.cfg.batch_size_limit {
+                            break;
+                        }
+                    }
+
+                    let batch = Batch::new(self.txs.drain(..txs_cnt).collect(), self.context.current());
+                    self.batches.insert(batch.digest, batch.clone());
+                    batch_network.0.send(Recipients::All, batch.serialize().into(), true).await.expect("failed to broadcast batch");
+                },
+                batch_message = batch_network.1.recv() => {
+                    let (sender, message) = batch_message.expect("Batch broadcast closed");
+                    let Some(batch) = Batch::deserialize(&message) else {
+                        warn!(?sender, "failed to deserialize batch");
+                        continue;
+                    };
+
+                    debug!(?sender, digest=?batch.digest, "received batch");
+                    let _ = self.batches.entry(batch.digest).or_insert(batch);
+                },
+            }
+        }
+    }
+}

--- a/chain/src/actors/mempool/mempool.rs
+++ b/chain/src/actors/mempool/mempool.rs
@@ -14,7 +14,7 @@ use futures::{channel::{mpsc, oneshot}, SinkExt, StreamExt};
 use commonware_macros::select;
 use governor::Quota;
 use rand::Rng;
-use tracing::{debug, warn};
+use tracing::{debug, warn, info};
 use governor::clock::Clock as GClock;
 use super::{handler::{Handler, self}, key::{self, MultiIndex, Value}, ingress, coordinator::Coordinator, archive::Wrapped};
 use crate::maybe_delay_between;
@@ -431,10 +431,8 @@ impl<
 
             select! {
                 mailbox_message = self.mailbox.next() => {
-                    // let message = mailbox_message.expect("Mailbox closed");
                     let Some(message) = mailbox_message else {
-                        // TODO: revisit this branch, it was .expect("Mailbox closed") and will panic after unit test is finished
-                        debug!("Mailbox closed, terminating...");
+                        info!("Mailbox closed, terminating...");
                         return;
                     };
                     match message {

--- a/chain/src/actors/mempool/mod.rs
+++ b/chain/src/actors/mempool/mod.rs
@@ -305,9 +305,6 @@ mod tests {
                             let Some(batch) = mailbox.get_batch_contain_tx(digest.clone()).await else {
                                 panic!("batch not found");
                             };
-                            if !batch.accepted {
-                                panic!("batch {} not acknowledged", batch.digest);
-                            }
                             info!("batch contain tx {} acknowledged", batch.digest);
                         }
                         if consume_batch {
@@ -342,10 +339,6 @@ mod tests {
                 context.with_label("simulation"), 
                 num_validators, 
                 &mut shares_vec).await;
-            // let mailboxes = Arc::new(Mutex::new(BTreeMap::<
-            //     PublicKey,
-            //     mempool::Mailbox<sha256::Digest>,
-            // >::new()));
             let mut collectors = BTreeMap::<PublicKey, super::collector::Mailbox<Ed25519, sha256::Digest>>::new();
             let mailboxes = spawn_validator_engines(
                 context.with_label("validator"), 
@@ -379,10 +372,6 @@ mod tests {
                 context.with_label("simulation"), 
                 num_validators, 
                 &mut shares_vec).await;
-            // let mailboxes = Arc::new(Mutex::new(BTreeMap::<
-            //     PublicKey,
-            //     mempool::Mailbox<sha256::Digest>,
-            // >::new()));
             let mailboxes = spawn_mempools(
                 context.with_label("mempool"), 
                 identity,

--- a/chain/src/actors/mempool/mod.rs
+++ b/chain/src/actors/mempool/mod.rs
@@ -1,0 +1,4 @@
+pub mod actor;
+pub mod ingress;
+pub mod coordinator;
+pub mod collector;

--- a/chain/src/actors/mempool/mod.rs
+++ b/chain/src/actors/mempool/mod.rs
@@ -5,6 +5,7 @@ pub mod collector;
 pub mod mempool;
 pub mod handler;
 pub mod key;
+pub mod archive;
 
 #[cfg(test)]
 mod tests {

--- a/chain/src/actors/mempool/mod.rs
+++ b/chain/src/actors/mempool/mod.rs
@@ -15,16 +15,15 @@ mod tests {
     use commonware_broadcast::linked::{Config, Engine};
     
     use governor::Quota;
-    use prometheus_client::metrics::info;
     use tracing::{debug, info, warn};
 
-    use commonware_cryptography::{bls12381::{dkg, primitives::{group::Share, poly}}, ed25519::PublicKey, sha256, Digest, Ed25519, Hasher, Scheme};
+    use commonware_cryptography::{bls12381::{dkg, primitives::{group::Share, poly}}, ed25519::PublicKey, sha256, Ed25519, Scheme};
     use commonware_macros::test_traced;
     use commonware_p2p::simulated::{Oracle, Receiver, Sender, Link, Network};
     use commonware_runtime::{deterministic::{Context, Executor}, Clock, Metrics, Runner, Spawner};
-    use futures::{channel::{mpsc, oneshot}, future::join_all};
+    use futures::channel::mpsc;
 
-    use super::{collector, ingress, mempool::{self, Mempool, RawTransaction}};
+    use super::{ingress, mempool::{self, Mempool, RawTransaction}};
 
     type Registrations<P> = HashMap<P, (
         (Sender<P>, Receiver<P>), 

--- a/chain/src/actors/mempool/mod.rs
+++ b/chain/src/actors/mempool/mod.rs
@@ -2,3 +2,282 @@ pub mod actor;
 pub mod ingress;
 pub mod coordinator;
 pub mod collector;
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::{BTreeMap, HashMap}, hash::Hash, sync::{Arc, Mutex}, time::Duration};
+    use bytes::Bytes;
+    use commonware_broadcast::linked::{Config, Engine};
+    use tracing::debug;
+
+    use commonware_cryptography::{bls12381::{self, dkg, primitives::{group::Share, poly}}, ed25519::PublicKey, sha256, Ed25519, Hasher, Scheme};
+    use commonware_macros::test_traced;
+    use commonware_p2p::simulated::{Oracle, Receiver, Sender, Link, Network};
+    use commonware_runtime::{deterministic::{Context, Executor}, Clock, Metrics, Runner, Spawner};
+    use futures::{channel::oneshot, future::join_all};
+
+    use super::collector;
+
+    type Registrations<P> = HashMap<P, ((Sender<P>, Receiver<P>), (Sender<P>, Receiver<P>))>;
+
+    #[allow(dead_code)]
+    enum Action {
+        Link(Link),
+        Update(Link),
+        Unlink,
+    }
+
+    async fn register_validators(
+        oracle: &mut Oracle<PublicKey>,
+        validators: &[PublicKey],
+    ) -> HashMap<PublicKey, (
+        (Sender<PublicKey>, Receiver<PublicKey>),
+        (Sender<PublicKey>, Receiver<PublicKey>),
+    )> { 
+        let mut registrations = HashMap::new();        
+        for validator in validators.iter() {
+            let (chunk_sender, chunk_receiver) = oracle.register(validator.clone(), 4).await.unwrap();
+            let (ack_sender, ack_receiver) = oracle.register(validator.clone(), 5).await.unwrap();
+            registrations.insert(validator.clone(), (
+                (chunk_sender, chunk_receiver),
+                (ack_sender, ack_receiver),
+            ));
+        }
+        registrations
+    }
+
+    async fn link_validators(
+        oracle: &mut Oracle<PublicKey>,
+        validators: &[PublicKey],
+        link: Link,
+        restrict_to: Option<fn(usize, usize, usize) -> bool>,
+    ) {
+        for (i1, v1) in validators.iter().enumerate() {
+            for (i2, v2) in validators.iter().enumerate() {
+                // Ignore self
+                if v2 == v1 {
+                    continue;
+                }
+
+                // Restrict to certain connections
+                if let Some(f) = restrict_to {
+                    if !f(validators.len(), i1, i2) {
+                        continue;
+                    }
+                }
+
+                // Add link
+                oracle
+                    .add_link(v1.clone(), v2.clone(), link.clone())
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+
+    async fn await_collectors(
+        context: Context,
+        collectors: &BTreeMap<PublicKey, collector::Mailbox<Ed25519, sha256::Digest>>,
+        threshold: u64,
+    ) {
+        let mut receivers = Vec::new();
+        for (sequencer, mailbox) in collectors.iter() {
+            // Create a oneshot channel to signal when the collector has reached the threshold.
+            let (tx, rx) = oneshot::channel();
+            receivers.push(rx);
+
+            // Spawn a watcher for the collector.
+            context.with_label("collector_watcher").spawn({
+                let sequencer = sequencer.clone();
+                let mut mailbox = mailbox.clone();
+                move |context| async move {
+                    loop {
+                        let tip = mailbox.get_tip(sequencer.clone()).await.unwrap_or(0);
+                        debug!(tip, ?sequencer, "collector");
+                        if tip >= threshold {
+                            let _ = tx.send(sequencer.clone());
+                            break;
+                        }
+                        context.sleep(Duration::from_millis(100)).await;
+                    }
+                }
+            });
+        }
+
+        // Wait for all oneshot receivers to complete.
+        let results = join_all(receivers).await;
+        assert_eq!(results.len(), collectors.len());
+    }
+
+        async fn initialize_simulation(
+        context: Context,
+        num_validators: u32,
+        shares_vec: &mut [Share],
+    ) -> (
+        Oracle<PublicKey>,
+        Vec<(PublicKey, Ed25519, Share)>,
+        Vec<PublicKey>,
+        Registrations<PublicKey>,
+    ) {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            commonware_p2p::simulated::Config {
+                max_size: 1024 * 1024,
+            },
+        );
+        network.start();
+
+        let mut schemes = (0..num_validators)
+            .map(|i| Ed25519::from_seed(i as u64))
+            .collect::<Vec<_>>();
+        schemes.sort_by_key(|s| s.public_key());
+        let validators: Vec<(PublicKey, Ed25519, Share)> = schemes
+            .iter()
+            .enumerate()
+            .map(|(i, scheme)| (scheme.public_key(), scheme.clone(), shares_vec[i]))
+            .collect();
+        let pks = validators
+            .iter()
+            .map(|(pk, _, _)| pk.clone())
+            .collect::<Vec<_>>();
+
+        let registrations = register_validators(&mut oracle, &pks).await;
+        let link = Link {
+            latency: 10.0,
+            jitter: 1.0,
+            success_rate: 1.0,
+        };
+        link_validators(&mut oracle, &pks, link, None).await;
+        (oracle, validators, pks, registrations)
+    }
+
+    fn spawn_proposer(
+        context: Context,
+        mailboxes: Arc<
+            Mutex<BTreeMap<PublicKey, super::ingress::Mailbox<sha256::Digest, PublicKey>>>,
+        >,
+        invalid_when: fn(u64) -> bool,
+    ) {
+        context
+            .clone()
+            .with_label("invalid signature proposer")
+            .spawn(move |context| async move {
+                let mut iter = 0;
+                loop {
+                    iter += 1;
+                    let mailbox_vec: Vec<super::ingress::Mailbox<sha256::Digest, PublicKey>> = {
+                        let guard = mailboxes.lock().unwrap();
+                        guard.values().cloned().collect()
+                    };
+                    for mut mailbox in mailbox_vec {
+                        let payload = Bytes::from(format!("hello world, iter {}", iter));
+                        let mut hasher = sha256::Sha256::default();
+                        hasher.update(&payload);
+
+                        // Inject an invalid digest by updating with the payload again.
+                        if invalid_when(iter) {
+                            hasher.update(&payload);
+                        }
+
+                        let digest = hasher.finalize();
+                        mailbox.broadcast(digest).await;
+                    }
+                    context.sleep(Duration::from_millis(250)).await;
+                }
+            });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_validator_engines(
+        context: Context,
+        identity: poly::Public,
+        pks: &[PublicKey],
+        validators: &[(PublicKey, Ed25519, Share)],
+        registrations: &mut Registrations<PublicKey>,
+        mailboxes: &mut BTreeMap<PublicKey, super::ingress::Mailbox<sha256::Digest, PublicKey>>,
+        collectors: &mut BTreeMap<PublicKey, super::collector::Mailbox<Ed25519, sha256::Digest>>,
+        refresh_epoch_timeout: Duration,
+        rebroadcast_timeout: Duration,
+    ) {
+        let namespace = b"my testing namespace";
+        for (validator, scheme, share) in validators.iter() {
+            let context = context.with_label(&validator.to_string());
+            let mut coordinator = super::coordinator::Coordinator::<PublicKey>::new(
+                identity.clone(),
+                pks.to_vec(),
+                *share,
+            );
+            coordinator.set_view(111);
+
+            let (app, app_mailbox) =
+                super::actor::Actor::<sha256::Digest, PublicKey>::new();
+            mailboxes.insert(validator.clone(), app_mailbox.clone());
+
+            let (collector, collector_mailbox) =
+                super::collector::Collector::<Ed25519, sha256::Digest>::new(
+                    namespace,
+                    *poly::public(&identity),
+                );
+            context.with_label("collector").spawn(|_| collector.run());
+            collectors.insert(validator.clone(), collector_mailbox);
+
+            let (engine, mailbox) = Engine::new(
+                context.with_label("engine"),
+                Config {
+                    crypto: scheme.clone(),
+                    application: app_mailbox.clone(),
+                    collector: collectors.get(validator).unwrap().clone(),
+                    coordinator,
+                    mailbox_size: 1024,
+                    verify_concurrent: 1024,
+                    namespace: namespace.to_vec(),
+                    epoch_bounds: (1, 1),
+                    height_bound: 2,
+                    refresh_epoch_timeout,
+                    rebroadcast_timeout,
+                    journal_heights_per_section: 10,
+                    journal_replay_concurrency: 1,
+                    journal_name_prefix: format!("broadcast-linked-seq/{}/", validator),
+                },
+            );
+
+            context.with_label("app").spawn(|_| app.run(mailbox));
+            let ((a1, a2), (b1, b2)) = registrations.remove(validator).unwrap();
+            engine.start((a1, a2), (b1, b2));
+        }
+    }
+
+    #[test_traced]
+    fn test_all_online() {
+        let num_validators: u32 = 4;
+        let quorum: u32 = 3;
+        let (runner, mut context, _) = Executor::timed(Duration::from_secs(30));
+        let (identity, mut shares_vec) = dkg::ops::generate_shares(&mut context, None, num_validators, quorum);        
+        shares_vec.sort_by(|a, b| a.index.cmp(&b.index));
+
+        runner.start(async move {
+            let (_oracle, validators, pks, mut registrations) = initialize_simulation(
+                context.with_label("simulation"), 
+                num_validators, 
+                &mut shares_vec).await;
+            let mailboxes = Arc::new(Mutex::new(BTreeMap::<
+                PublicKey,
+                super::ingress::Mailbox<sha256::Digest, PublicKey>,
+            >::new()));
+            let mut collectors = BTreeMap::<PublicKey, super::collector::Mailbox<Ed25519, sha256::Digest>>::new();
+            spawn_validator_engines(
+                context.with_label("validator"), 
+                identity.clone(), 
+                &pks, 
+                &validators, 
+                &mut registrations, 
+                &mut mailboxes.lock().unwrap(), 
+                &mut collectors, 
+                Duration::from_millis(100), 
+                Duration::from_secs(5)
+            );
+            spawn_proposer(context.with_label("proposer"), mailboxes.clone(), |_| false);
+            await_collectors(context.with_label("collector"), &collectors, 100).await;
+        });
+    }
+}

--- a/chain/src/actors/mod.rs
+++ b/chain/src/actors/mod.rs
@@ -1,2 +1,3 @@
 pub mod application;
 pub mod syncer;
+pub mod mempool;

--- a/chain/src/actors/syncer/actor.rs
+++ b/chain/src/actors/syncer/actor.rs
@@ -287,7 +287,7 @@ impl<B: Blob, R: Rng + Spawner + Metrics + Clock + GClock + Storage<B>, I: Index
             let mut resolver = resolver.clone();
             let last_view_processed = last_view_processed.clone();
             let verified = verified.clone();
-            let notarized = notarized.clone();
+            let notarized: Wrapped<TwoCap, Digest, B, R> = notarized.clone();
             let finalized = finalized.clone();
             let blocks = blocks.clone();
             move |_| async move {

--- a/chain/src/bin/setup.rs
+++ b/chain/src/bin/setup.rs
@@ -488,7 +488,6 @@ fn generate_local(sub_matches: &ArgMatches) {
             name: scheme.public_key().to_string(),
             region: "local".to_string(),
             ip: "127.0.0.1".parse().expect("invalid IP address"),
-            port: PORT + index as u16,
         };
         peers.push(peer);
     }

--- a/chain/src/bin/validator.rs
+++ b/chain/src/bin/validator.rs
@@ -7,7 +7,7 @@ use commonware_broadcast::linked;
 use commonware_cryptography::{
     bls12381::primitives::{
         group::{self, Element},
-        poly::{self, public},
+        poly,
     }, ed25519::{PrivateKey, PublicKey}, sha256, Ed25519, Scheme
 };
 use commonware_deployer::ec2::Peers;
@@ -16,7 +16,7 @@ use commonware_runtime::{tokio, Clock, Metrics, Network, Runner, Spawner};
 use commonware_utils::{from_hex_formatted, hex, quorum};
 use futures::future::try_join_all;
 use governor::Quota;
-use prometheus_client::metrics::{gauge::Gauge};
+use prometheus_client::metrics::gauge::Gauge;
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -223,7 +223,7 @@ fn main() {
         let mempool_batch_limit = Quota::per_second(NonZeroU32::new(8).unwrap());
         let mempool_batch_broadcaster = network.register(
             MEMPOOL_BATCH_CHANNEL,
-            mempool_ack_limit,
+            mempool_batch_limit,
             config.message_backlog,
             Some(3),
         );
@@ -232,7 +232,7 @@ fn main() {
         let mempool_backfill_limit = Quota::per_second(NonZeroU32::new(8).unwrap());
         let mempool_backfill_broadcaster = network.register(
             MMEPOOL_BACKFILL_CHANNEL,
-            mempool_ack_limit,
+            mempool_backfill_limit,
             config.message_backlog,
             Some(3),
         );

--- a/chain/src/bin/validator.rs
+++ b/chain/src/bin/validator.rs
@@ -8,7 +8,7 @@ use commonware_cryptography::{
     bls12381::primitives::{
         group::{self, Element},
         poly,
-    }, ed25519::{PrivateKey, PublicKey}, sha256, Bls12381, Ed25519, Scheme
+    }, ed25519::{PrivateKey, PublicKey}, sha256, Ed25519, Scheme
 };
 use commonware_deployer::ec2::Peers;
 use commonware_p2p::authenticated;
@@ -16,7 +16,7 @@ use commonware_runtime::{tokio, Clock, Metrics, Network, Runner, Spawner};
 use commonware_utils::{from_hex_formatted, hex, quorum};
 use futures::future::try_join_all;
 use governor::Quota;
-use prometheus_client::metrics::{self, gauge::Gauge};
+use prometheus_client::metrics::{gauge::Gauge};
 use std::{
     collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -30,7 +30,7 @@ use sysinfo::{Disks, System};
 use tracing::{error, info, Level};
 
 const SYSTEM_METRICS_REFRESH: Duration = Duration::from_secs(5);
-const METRICS_PORT: u16 = 9090;
+// const METRICS_PORT: u16 = 9090;
 
 const VOTER_CHANNEL: u32 = 0;
 const RESOLVER_CHANNEL: u32 = 1;

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -69,6 +69,8 @@ pub struct Config {
     pub worker_threads: usize,
     pub log_level: String,
 
+    pub metrics_port: u16,
+
     pub allowed_peers: Vec<String>,
     pub bootstrappers: Vec<String>,
 

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod actors;
 pub mod engine;
+pub mod macros;
 
 /// Trait for interacting with an indexer.
 pub trait Indexer: Clone + Send + Sync + 'static {

--- a/chain/src/macros/mod.rs
+++ b/chain/src/macros/mod.rs
@@ -1,0 +1,45 @@
+/// A macro that conditionally inserts a random delay between two asynchronous expressions during tests.
+///
+/// When compiled in test mode (`#[cfg(test)]`), a random delay is inserted using the provided context's
+/// `sleep` method. In non-test builds, the expressions are executed sequentially without delay.
+/// The macro discards the return values of the expressions so that it always returns `()`.
+///
+/// # Example
+///
+/// ```rust
+/// // Assume that `self.context` is defined and provides an async sleep method,
+/// // and that `batch_network` and `app_mailbox` are in scope.
+/// maybe_delay_between!(self.context,
+///     app_mailbox.broadcast(batch.digest).await;
+///     batch_network.0.send(Recipients::All, batch.serialize().into(), true)
+///         .await.expect("failed to broadcast batch")
+/// );
+/// ```
+///
+/// You can also include an optional trailing semicolon after the second expression:
+///
+/// ```rust
+/// maybe_delay_between!(self.context,
+///     app_mailbox.broadcast(batch.digest).await;
+///     batch_network.0.send(Recipients::All, batch.serialize().into(), true)
+///         .await.expect("failed to broadcast batch");
+/// );
+/// ```
+#[macro_export]
+macro_rules! maybe_delay_between {
+    ($context:expr, $first:expr; $second:expr $(;)?) => {{
+        // Execute the first asynchronous expression and discard its value.
+        let _ = $first;
+        // If we're in a test build, add a random delay using the provided context.
+        #[cfg(test)]
+        {
+            use rand::Rng;
+            let delay_ms = rand::thread_rng().gen_range(50..150); // random delay between 50 and 150 ms
+            $context.sleep(std::time::Duration::from_millis(delay_ms)).await;
+        }
+        // Execute the second asynchronous expression and discard its value.
+        let _ = $second;
+        // Return unit.
+        ()
+    }};
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CWD=$(pwd)
+
+cd chain && cargo build --bin validator --target x86_64-unknown-linux-gnu --target-dir ../targets 
+cp ../targets/x86_64-unknown-linux-gnu/debug/validator $CWD

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-cd ./chain
-
-NUM_VALIDATORS=${NUM_VALIDATORS:-5}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd ./chain
+
+NUM_VALIDATORS=${NUM_VALIDATORS:-5}

--- a/scripts/start_validators.sh
+++ b/scripts/start_validators.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+cd ./chain
+
+NUM_VALIDATORS=${NUM_VALIDATORS:-5}
+LOG_DIR=/tmp/alto-logs
+PID_FILE=${LOG_DIR}/validators.pid
+FLAG_FILE=${LOG_DIR}/network_running.flag
+
+# Check if a network is already running
+if [ -f ${FLAG_FILE} ]; then
+    echo "Existing network detected (flag file ${FLAG_FILE} exists). Aborting launch."
+    exit 1
+fi
+
+# Create log directory if it doesn't exist and clear any old PID file
+mkdir -p ${LOG_DIR}
+[ -f ${PID_FILE} ] && rm ${PID_FILE}
+
+# Create the flag file to indicate that the network is running
+touch ${FLAG_FILE}
+
+for i in $(seq 0 $(($NUM_VALIDATORS - 1))); do
+    echo "Launching validator $i..."
+    cargo run --bin validator -- --peers assets/peers.yaml --config assets/validator${i}.yaml > ${LOG_DIR}/validator${i}.log 2>&1 &
+    echo $! >> ${PID_FILE}
+done
+
+echo "Validators launched. PIDs stored in ${PID_FILE}."

--- a/scripts/stop_validators.sh
+++ b/scripts/stop_validators.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+LOG_DIR=/tmp/alto-logs
+PID_FILE=${LOG_DIR}/validators.pid
+FLAG_FILE=${LOG_DIR}/network_running.flag
+
+if [ ! -f ${PID_FILE} ]; then
+    echo "No validators are running (PID file not found)."
+    exit 1
+fi
+
+while read pid; do
+    echo "Stopping validator process with PID ${pid}..."
+    kill ${pid} 2>/dev/null
+done < ${PID_FILE}
+
+rm ${PID_FILE}
+rm -f ${FLAG_FILE}
+echo "All validators have been stopped and the network flag has been removed."


### PR DESCRIPTION
mempool functionality that utilizes broadcast commonware/broadcast primitive, it implements exactly the same functionality as described in blog: https://commonware.xyz/blogs/commonware-broadcast.html, where one block references batches of txs and there exists multiple txs sequencer that sequence batches through the broadcast primitive. 

A batch will be added to a mempool only when it is acknowledged and they are added in the original order the txs sequencer sequence. Acknowlegements of batches are pushed to a FIFO, which will be used for `ConsumeBatches` and `ConsumedBatches` operations to pick up & consume batches in order. 

The correctness is guaranteed that 
1. GetBatch is called first on verification of a batch or a block
2. ConsumeBatches is called on finalization of a block.
